### PR TITLE
apply ref protections settings as code

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,71 @@
+repository:
+  name: release-it-gh-workflow
+  description: Reusable GitHub Actions workflow for [release-it](https://github.com/release-it/release-it)
+  default_branch: main
+
+  # Prevent strategies other than basic merge, as they interfere with conventional changelog version inference
+  allow_squash_merge: false
+  allow_rebase_merge: false
+  # Instead, merge by merge commit
+  allow_merge_commit: true
+  # Clean up branches when PRs merge
+  delete_branch_on_merge: true
+
+rulesets:
+  - name: Tags rules
+    target: tag
+    enforcement: active
+    conditions:
+      ref_name:
+        include:
+          - "~ALL"
+        exclude: []
+    bypass_actors:
+      - actor_id: 1049549 # release-it-gh-workflow release-it app
+        actor_type: Integration
+        bypass_mode: always
+    rules:
+      - type: creation
+      - type: deletion
+      - type: non_fast_forward
+      - type: update
+  - name: Default branch rules
+    target: branch
+    enforcement: active
+    conditions:
+      ref_name:
+        include:
+          - "~DEFAULT_BRANCH"
+        exclude: []
+    bypass_actors:
+      - actor_id: 5 # Based on https://registry.terraform.io/providers/integrations/github/latest/docs/resources/organization_ruleset#bypass_actors
+        actor_type: RepositoryRole
+        bypass_mode: pull_request
+    rules:
+      - type: creation
+      - type: deletion
+      - type: non_fast_forward
+      - type: pull_request
+        parameters:
+          dismiss_stale_reviews_on_push: true
+          require_code_owner_review: true
+          require_last_push_approval: false
+          # Use codeowners vs. review count, so codeowners can merge without review
+          required_approving_review_count: 0
+          required_review_thread_resolution: true
+      # Require workflow job as check to enable PR up-to-date rule
+      - type: required_status_checks
+        parameters:
+          required_status_checks:
+            - context: Release-it workflow / Release-it dry-run
+              integration_id: 15368 # GitHub Actions integration ID
+          # Requires PR branches to be up-to-date with target
+          strict_required_status_checks_policy: true
+
+collaborators: [] # No collaborators defined
+
+environments:
+  - name: Repo release
+    deployment_branch_policy:
+      custom_branches:
+        - main

--- a/.github/workflows/.self-push-workflow.yaml
+++ b/.github/workflows/.self-push-workflow.yaml
@@ -4,7 +4,10 @@ name: Push workflow
 on: push
 jobs:
   release-it-workflow:
-    permissions:
-      contents: write
     # Use a local reference to the workflow file to use version defined by the repo state
     uses: ./.github/workflows/release-it-workflow.yaml
+    with:
+      app-id: 1049549 # release-it-gh-workflow release-it app
+      app-environment: Repo release
+    secrets:
+      app-secret: ${{ secrets.RELEASE_IT_GITHUB_APP_KEY }} # Secret belonging to the Repo release environment

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Eric Weber
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -55,25 +55,62 @@ jobs:
       release-it-config: ./.release-it.json
 ```
 
+### Merge strategies settings-as-code usage
+
+If using conventional-changelog (default), or other release-it plugins that require consistent git history, it is necessary to follow a [merge-commit merge strategy](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/about-merge-methods-on-github). It is recommended to apply settings to enforce this using [Probot settings as code](https://github.com/repository-settings/app):
+
+```yaml
+repository:
+  ...
+  # Prevent strategies other than basic merge, as they interfere with conventional changelog version inference
+  allow_squash_merge: false
+  allow_rebase_merge: false
+  # Instead, merge by merge commit
+  allow_merge_commit: true
+  # Clean up branches when PRs merge
+  delete_branch_on_merge: true
+```
+
 ### Usage with protected tags
 
-With [rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) configured to protect tag creation, the release-it workflow will not have access to create tags and releases. Instead, it must authenticate to act as a [GitHub App](https://docs.github.com/en/apps/overview). This may be configured via settings-as-code (see [Protected tags settings-as-code usage](#protected-tags-settings-as-code-usage)). The steps to instead manually configure an app for this are as follows:
+With [rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) configured to protect tag creation, the release-it workflow will not have access to create tags and releases. Instead, it must authenticate to act as a [GitHub App](https://docs.github.com/en/apps/overview). The steps to instead manually configure an app for this are as follows:
+
+Follow [this link](https://github.com/settings/apps/new?name=YOUR_REPO_NAME%20CI%20release-it&url=https://github.com/YOUR_REPO_URL&description=This%20app%20enables%20the%20YOUR_REPO_NAME%20GitHub%20Actions%20workflow%20to%20authenticate%20as%20an%20app%20to%20publish%20tags%20and%20releases&webhook_active=false&contents=write) to create an App:
+
+```
+https://github.com/settings/apps/new?name=YOUR_REPO_NAME%20CI%20release-it&url=https://github.com/YOUR_REPO_URL&description=This%20app%20enables%20the%20YOUR_REPO_NAME%20GitHub%20Actions%20workflow%20to%20authenticate%20as%20an%20app%20to%20publish%20tags%20and%20releases&webhook_active=false&contents=write
+```
+
+<details>
+<summary><i>Alternatively, follow these manual steps to achieve the same</i></summary>
 
 1. Navigate to [GitHub Settings > Developer Settings](https://github.com/settings/apps)
 1. Create a New GitHub App
 1. Under Webhook, disable Active
 1. Under Permssions, set Contents to Read and Write
-1. After creating the app, under Private keys, Generate a private key
+
+</details>
+
+<br>
+
+To configure workflow access to the App:
+
+1. After creating the App, under Private keys, Generate a private key
 1. Copy the App ID; this must be provided as the `app-id` input to the workflow
 1. Select Install App, and Install to your user/organization
 1. Select Only select repositories, and select the appropriate repository from the dropdown
-1. From the repo Settings page, create a new environment to manage access to the app, via Environments > New environment
-1. Copy the environment name; this must be provided as the `app-environment` input to the workflow
-1. Enable desired protections; Deployment branches and tags set to the default branch recommended
-1. Choose Add environment secret, and paste the App private key .pem file contents generated earlier as the secret value
+1. If using repo settings-as-code, apply the settings for the environment (see [Protected tags settings-as-code usage](#protected-tags-settings-as-code-usage)). 
+    <details>
+    <summary><i>Otherwise, follow these steps</i></summary>
+
+      1. From the repo Settings page, create a new environment to manage access to the app, via Environments > New environment
+      1. Copy the environment name; this must be provided as the `app-environment` input to the workflow
+      1. Enable desired protections; Deployment branches and tags set to the default branch recommended
+    </details>
+1. From the environment configuration page, choose Add environment secret, and paste the App private key .pem file contents generated earlier as the secret value
 1. Copy the secret name; this must be provided as the `app-secret` job secret to the workflow
 
-The app must be granted permissions to bypass the tag protections. To configure this, add it as a [bypass actor](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-organization-settings/managing-rulesets-for-repositories-in-your-organization#editing-a-ruleset) to the applicable tag protection ruleset.
+The app must be granted permissions to bypass the tag protections. To configure this, add it as a [bypass actor](https://docs.github.com/en/enterprise-cloud@latest/organizations/managing-organization-settings/managing-rulesets-for-repositories-in-your-organization#editing-a-ruleset) to the applicable tag protection ruleset (see [Protected tags settings-as-code usage](#protected-tags-settings-as-code-usage)).
 
 Once the app is configured and inputs provided, it replaces the need for granting `contents: write` permissions to the workflow. An example workflow configuration for this use-case:
 
@@ -83,7 +120,7 @@ jobs:
   release-it-workflow:
     uses: rcwbr/release-it-gh-workflow/.github/workflows/release-it-workflow.yaml@0.1.0
     with:
-      app-id: 1033419 # release-it-docker CI release-it app
+      app-id: 1049549 # release-it-gh-workflow release-it app
       app-environment: Repo release
     secrets:
       app-secret: ${{ secrets.RELEASE_IT_GITHUB_APP_KEY }} # Secret belonging to the Repo release environment
@@ -91,9 +128,27 @@ jobs:
 
 ### Protected tags settings-as-code usage
 
-TODO
+It is recommended to configure repos for this workflow using [Probot settings as code](https://github.com/repository-settings/app). To configure tag protection rules, include the following in the `.github/settings.yml` file:
 
-Using the [Probot settings GitHub App](https://probot.github.io/apps/settings/), specify the tag protection rules in the `.github/settings.yml` file:
+```yaml
+rulesets:
+  ...
+  - name: Tags rules
+    target: tag
+    enforcement: active
+    conditions:
+      ref_name:
+        include:
+          - "~ALL"
+        exclude: []
+    rules:
+      - type: creation
+      - type: deletion
+      - type: non_fast_forward
+      - type: update
+```
+
+The above settings prevent any edit of tags, including creation. To grant release-it automation access to create tags, add it to the tags rule as a bypass actor, using the ID of the GitHub App created for this automation (see [Usage with protected tags](#usage-with-protected-tags)):
 
 ```yaml
 rulesets:
@@ -101,9 +156,69 @@ rulesets:
     target: tag
     ...
     bypass_actors:
-      - actor_id: 1033419
+      - actor_id: 1049549 # release-it-gh-workflow release-it app
         actor_type: Integration
         bypass_mode: always
+```
+
+Lastly, provision an environment for managing access to the GitHub App secret. To limit that access to events on the `main` branch, use a custom branch policy:
+
+```yaml
+environments:
+  - name: Repo release # Must match the app-environment workflow input
+    deployment_branch_policy:
+      custom_branches:
+        - main
+```
+
+> :warning: Note that an environment configured as code as above will not be provisioned until pushed to the repo default branch. An initial merge will fail to release as the App secret must be manually applied to the environment after merging. However, the release workflow may be retried once all configuration is in place, and should then succeed.
+
+### Required checks settings-as-code usage
+
+To require successful workflow release-it dry-runs on PRs, branch protections and required checks may be configured via [Probot settings as code](https://github.com/repository-settings/app).
+
+Apply basic branch protection settings similar to these:
+
+```yaml
+rulesets:
+  ...
+  - name: Default branch rules
+    target: branch
+    enforcement: active
+    conditions:
+      ref_name:
+        include:
+          - "~DEFAULT_BRANCH"
+        exclude: []
+    rules:
+      - type: creation
+      - type: deletion
+      - type: non_fast_forward
+      - type: pull_request
+        parameters:
+          dismiss_stale_reviews_on_push: true
+          require_code_owner_review: true
+          require_last_push_approval: false
+          # Use codeowners vs. review count, so codeowners can merge without review
+          required_approving_review_count: 0
+          required_review_thread_resolution: true
+```
+
+And add a required status check for the release-it dry-run job:
+
+```yaml
+rulesets:
+  ...
+  - name: Default branch rules
+      ...
+      # Require workflow job as check to enable PR up-to-date rule
+      - type: required_status_checks
+        parameters:
+          required_status_checks:
+            - context: Release-it workflow / Release-it dry-run
+              integration_id: 15368 # GitHub Actions integration ID
+          # Requires PR branches to be up-to-date with target
+          strict_required_status_checks_policy: true
 ```
 
 ## Output


### PR DESCRIPTION
Closes #7 

Closes #8 

> ## What
> 
> Document usage of settings-as-code to protect release-it owned tags, and configuration to grant the release-it workflow access to bypass the protection.
> 
> ## Why
> 
> To reduce manual and untracked steps to configure a safe release-it deployment environment.
> 
> ## How
> 
> MD docs to leverage [Probot settings app](https://probot.github.io/apps/settings/) alongside [gha-gcp-opentofu](https://github.com/rcwbr/gha-gcp-opentofu/tree/main) with necessary resource