### PR TITLE
Prevent job trigger on commits made by release-it

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,6 +1,6 @@
 repository:
   name: release-it-gh-workflow
-  description: Reusable GitHub Actions workflow for [release-it](https://github.com/release-it/release-it)
+  description: Reusable GitHub Actions workflow for release-it (https://github.com/release-it/release-it)
   default_branch: main
 
   # Prevent strategies other than basic merge, as they interfere with conventional changelog version inference

--- a/.github/workflows/release-it-workflow.yaml
+++ b/.github/workflows/release-it-workflow.yaml
@@ -79,7 +79,8 @@ jobs:
   release-it:
     name: Release-it
     # By default, run release-it in contexts for the main branch
-    if: ${{ inputs.always-release || github.ref == inputs.default-branch || github.ref == format('refs/heads/{0}', inputs.default-branch) }}
+    # Skip if the commit pattern is "release: ", per https://github.com/rcwbr/release-it-docker/blob/485ec351cb07c71d39480d2fb03f529d77789067/base/.release-it.json#L4
+    if: "${{ !startsWith(github.event.head_commit.message, 'release: ') && ( inputs.always-release || github.ref == inputs.default-branch || github.ref == format('refs/heads/{0}', inputs.default-branch) ) }}"
     runs-on: ubuntu-24.04
     container:
       image: ${{ inputs.release-it-image }}


### PR DESCRIPTION
Closes #15 

> ## What
> 
> Prevent release-it workflow trigger by commits created by release-it itself, e.g. in the file-bumper model.
> 
> ## Why
> 
> Workflows triggered by release-it-created commits results in looped creation of releases and workflows.
> 
> ## How
> 
> Limit workflow runs to cases where the commit message does not match the release pattern.