### PR TITLE
Solve detached HEAD error in pull_request workflows

### DIFF
--- a/.github/workflows/release-it-workflow.yaml
+++ b/.github/workflows/release-it-workflow.yaml
@@ -60,6 +60,8 @@ jobs:
         uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
+          # Needed for pull_request workflow types
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
       -
         name: Release-it
         shell: bash


### PR DESCRIPTION
Closes #20 

> ## What
> 
> Fix behavior of dry-run workflow in `pull_request` workflows resulting in errors:
> 
> ```bash
> ERROR fatal: ref HEAD is not a symbolic ref
> ```
> 
> ## Why
> 
> Dry-run workflow should be usable in `pull_request` and `push` workflow types
> 
> ## How
> 
> Configure checkout to forcibly use the ref of the event (inspired by [this](https://github.com/actions/checkout/blob/85e6279cec87321a52edac9c87bce653a07cf6c2/README.md#push-a-commit-to-a-pr-using-the-built-in-token)):
> 
> ```yaml
>         with:
>           ref: ${{ github.ref }}
> ```