### PR TITLE
fix: matrix logic to support PR workflows

### DIFF
--- a/.github/workflows/release-it-workflow.yaml
+++ b/.github/workflows/release-it-workflow.yaml
@@ -93,7 +93,7 @@ jobs:
         with:
           fetch-depth: 0
           # Needed for pull_request workflow types
-          ref: ${{ ( !matrix.mode == 'release' && github.event_name == 'pull_request' ) && github.head_ref || github.ref }}
+          ref: ${{ ( matrix.mode != 'release' && github.event_name == 'pull_request' ) && github.head_ref || github.ref }}
           token: ${{ ( matrix.mode == 'release' && inputs.app-id != '' ) && steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
       -
         name: Download artifact


### PR DESCRIPTION
Closes #24 

> ## What
> 
> Mount the workspace for release-it to the same path as on the host.
> 
> ## Why
> 
> To allow processes owned by release-it to also mount the workspace.
> 
> ## How
> 
> `volumes` and `working-directory` to `github.workspace`
> 